### PR TITLE
fix color bug and awk pretty

### DIFF
--- a/thor
+++ b/thor
@@ -54,7 +54,7 @@ function thor () {
          if [ -z $cmd ]; then
            cmd=$THORDEFAULT
          fi
-         target=`ls -l $THORPATH | awk '{print $9, $0}' | grep ^"$cmd" | awk '{print $12}'`
+         target=`ls -l -color=none $THORPATH | awk '{if ($9=="$cmd") print $11}'`
          if [ -z $target ]; then
            echo "not match pin: $cmd"
          else


### PR DESCRIPTION
if `ls` command colored 

the `ls -l` will be like this

```
lrwxrwxrwx 1 zheng zheng 18 Apr 11 16:00 ^[[0m^[[01;36mconfig^[[0m -> ^[[01;34m/home/xxxx/conf
ig^[[0m/
```

so, with origin shell , it cant be use `thor config` can't match it !!!

so I fix it

then , we can use awk more elegant
